### PR TITLE
feat: Stretchモデルの作成とシードデータ追加（#2）

### DIFF
--- a/app/models/stretch.rb
+++ b/app/models/stretch.rb
@@ -1,0 +1,14 @@
+class Stretch < ApplicationRecord
+  enum target_area: {
+    shoulder: 0,
+    neck: 1,
+    lower_back: 2
+  }
+
+  validates :name, presence: true, length: { maximum: 10 }
+  validates :description, presence: true, length: { maximum: 100 }
+  validates :target_area, presence: true
+  validates :steps, presence: true
+
+  has_many :records, dependent: :destroy
+end

--- a/db/migrate/20260409070809_create_stretches.rb
+++ b/db/migrate/20260409070809_create_stretches.rb
@@ -1,0 +1,13 @@
+class CreateStretches < ActiveRecord::Migration[7.2]
+  def change
+    create_table :stretches do |t|
+      t.string :name, null: false
+      t.text :description, null: false
+      t.string :image_path, null: false 
+      t.integer :target_area, null: false
+      t.text :steps, null: false
+
+      t.timestamps 
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 0) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_09_070809) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "stretches", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description", null: false
+    t.string "image_path", null: false
+    t.integer "target_area", null: false
+    t.text "steps", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,79 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+
+Stretch.destroy_all
+
+puts "ストレッチデータを作成中..."
+
+# 肩のストレッチ
+Stretch.create!([
+  {
+    name: '肩回し',
+    description: '肩をゆっくり回して血行を促進',
+    target_area: :shoulder,
+    steps: "1. 背筋を伸ばして座る\n2. 両肩を耳に近づけるように上げる\n3. 後ろ → 下 → 前と大きく回す\n4. 前回し・後ろ回しを各5回行う",
+    image_path: 'shoulder_rotation.png'
+  },
+  {
+    name: '肩甲骨寄せ',
+    description: '肩甲骨を寄せて肩周りをほぐす',
+    target_area: :shoulder,
+    steps: "1. 背筋を伸ばして座る\n2. 両手を背中で組む\n3. 肩甲骨を寄せながら胸を開く\n4. 20秒キープを3セット行う",
+    image_path: 'shoulder_blade.png'
+  },
+  {
+    name: '腕のクロスストレッチ',
+    description: '腕を胸の前で伸ばしてほぐす',
+    target_area: :shoulder,
+    steps: "1. 右腕を胸の前に伸ばす\n2. 左手で右肘を抱える\n3. ゆっくりと左側に引き寄せる\n4. 30秒キープ後、反対側も行う",
+    image_path: 'shoulder_cross.png'
+  }
+])
+
+# 首のストレッチ
+Stretch.create!([
+  {
+    name: '首の側屈',
+    description: '首を横に倒して首筋を伸ばす。スマホ首の改善に効果的です。',
+    target_area: :neck,
+    steps: "1. 背筋を伸ばして座る\n2. 右手で頭の左側を優しく押さえる\n3. ゆっくりと首を右に倒す\n4. 30秒キープ後、反対側も行う",
+    image_path: 'neck_stretch.png'
+  },
+
+  {
+    name: '首の回旋',
+    description: '首をゆっくり回して柔軟性を高める',
+    target_area: :neck,
+    steps: "1. 背筋を伸ばして座る\n2. 首をゆっくり右に回す\n3. 正面 → 右 → 正面 → 左の順に動かす\n4. 各方向で3秒キープ",
+    image_path: 'neck_rotation.png'
+  }
+])
+
+# 腰のストレッチ
+Stretch.create!([
+  {
+    name: '座位ツイスト',
+    description: '座ったまま腰をひねってリフレッシュ',
+    target_area: :lower_back,
+    steps: "1. 背筋を伸ばして座る\n2. 右手を左膝の外側に置く\n3. ゆっくりと体を左にひねる\n4. 30秒キープ後、反対側も行う",
+    image_path: 'lower_back_twist.png'
+  },
+
+  {
+    name: '前屈',
+    description: '座ったまま前に倒れて腰を伸ばす',
+    target_area: :lower_back,
+    steps: "1. 椅子に浅く座る\n2. 足を肩幅に開く\n3. 息を吐きながら上体を前に倒す\n4. 30秒キープして戻る",
+    image_path: 'forward_bend.png'
+  }
+])
+
+
+puts "☑️ #{Stretch.count}件のストレッチデータを作成しました！"
+
+# 各部位ごとの件数を表示
+puts " - 肩: #{Stretch.shoulder.count}件"
+puts " - 首: #{Stretch.neck.count}件"
+puts " - 腰: #{Stretch.lower_back.count}件"

--- a/test/fixtures/stretches.yml
+++ b/test/fixtures/stretches.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  description: MyText
+  image_path: MyString
+  target_area: 1
+  steps: MyText
+
+two:
+  name: MyString
+  description: MyText
+  image_path: MyString
+  target_area: 1
+  steps: MyText

--- a/test/models/stretch_test.rb
+++ b/test/models/stretch_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class StretchTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
issue #2 で提起された Stretchモデルを作成しました。

## 変更内容
- Stretchモデルの作成（カラム：name, description, target_area, steps, image_path）
- マイグレーションの実行
- シードデータの作成

## 動作確認
rails consoleを立ち上げて以下のデータが取得出来るかを確認。
      
- [ ] `Stretch.count` でストレッチデータが7件シードデータとして入っているか
- [ ] `Stretch.shoulder` で肩のストレッチデータを３件取得出来るか
- [ ] `Stretch.first.name` で取得する最初のストレッチデータのnameが"肩回し"であるか


## 関連 issue
Closes #2