### PR TITLE
feat:気になる部位画面(トップページ)の実装(#9)

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,4 @@
+class StaticPagesController < ApplicationController
+  def top
+  end
+end

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -1,0 +1,2 @@
+module StaticPagesHelper
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,26 +1,24 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Myapp" %></title>
+    <title><%= content_for(:title) || "ストレッチミニアプリ" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= yield :head %>
-
-    <link rel="manifest" href="/manifest.json">
-    <link rel="icon" href="/icon.png" type="image/png">
-    <link rel="icon" href="/icon.svg" type="image/svg+xml">
-    <link rel="apple-touch-icon" href="/icon.png">
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
-    <main class="container mx-auto mt-28 px-5 flex">
+  <body class="bg-blue-200 flex flex-col min-h-screen">
+    <%= render 'shared/header' %>
+
+    <main class="flex-glow container mx-auto px-4 py-8">
       <%= yield %>
     </main>
+
+    <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,5 @@
+<footer class="bg-gray-800 text-white p-2 mt-auto">
+  <div class="container mx-auto text-center">
+    <p class="text-sm">&copy; 2026 ストレッチミニアプリ</p>
+  </div>
+</footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,7 @@
+<header class="bg-gray-800 text-white p-2">
+  <div class="container mx-auto text-center">
+    <h1 class="text-2xl font-bold">
+      <%= link_to 'ストレッチミニアプリ', root_path, class: 'hover: text-white' %>
+    </h1>
+  </div>
+</header>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,0 +1,35 @@
+<div class="max-w-4xl mx-auto">
+  <h2 class="text-3xl font-bold text-center mb-8">気になる部位を選んでください</h2>
+
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+    <!-- 肩 -->
+    <div class="bg-white rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow cursor-pointer">
+      <div class="text-center">
+        <div class="text-6xl mb-4">💪</div>
+        <h3 class="text-2xl font-bold mb-2">肩</h3>
+        <p class="text-gray-600 mb-4">肩こりや肩の疲れに</p>
+        <%= link_to 'タップして選択', '#', class: 'inline-block bg-blue-500 text-white px-6 py-2 rounded-lg hover:bg-blue-600 transition-colors' %>
+      </div>
+    </div>
+
+    <!-- 首 -->
+    <div class="bg-white rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow cursor-pointer">
+      <div class="text-center">
+        <div class="text-6xl mb-4">🦒</div>
+        <h3 class="text-2xl font-bold mb-2">首</h3>
+        <p class="text-gray-600 mb-4">首の疲れやこりに</p>
+        <%= link_to 'タップして選択', '#', class: 'inline-block bg-blue-500 text-white px-6 py-2 rounded-lg hover:bg-blue-600 transition-colors' %>
+      </div>
+    </div>
+    
+    <!-- 腰 -->
+    <div class="bg-white rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow cursor-pointer">
+      <div class="text-center">
+        <div class="text-6xl mb-4">🧘</div>
+        <h3 class="text-2xl font-bold mb-2">腰</h3>
+        <p class="text-gray-600 mb-4">腰痛や腰の疲れに</p>
+        <%= link_to 'タップして選択', '#', class: 'inline-block bg-blue-500 text-white px-6 py-2 rounded-lg hover:bg-blue-600 transition-colors' %>
+      </div>
+    </div>    
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get "static_pages/top"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
@@ -6,9 +7,9 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
   # Render dynamic PWA files from app/views/pwa/*
-  get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-  get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
+  # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
+  # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "static_pages#top"
 end

--- a/db/migrate/20260409070809_create_stretches.rb
+++ b/db/migrate/20260409070809_create_stretches.rb
@@ -3,11 +3,11 @@ class CreateStretches < ActiveRecord::Migration[7.2]
     create_table :stretches do |t|
       t.string :name, null: false
       t.text :description, null: false
-      t.string :image_path, null: false 
+      t.string :image_path, null: false
       t.integer :target_area, null: false
       t.text :steps, null: false
 
-      t.timestamps 
+      t.timestamps
     end
   end
 end

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class StaticPagesControllerTest < ActionDispatch::IntegrationTest
+  test "should get top" do
+    get static_pages_top_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
issue #9  で提起された 気になる部位画面（トップページ）を実装する。

## 変更内容
- ルーティングの設定

- コントローラーの作成
  - `static_pages_controller`の生成
  - topアクションの定義

- ビューの作成（部位ボタン、ヘッダー、フッター）
- `top.html.erb`の生成・編集
  - パーシャルファイルの生成（header / footer）


## 動作確認
      
- [ ] ヘッダー、フッターが表示されているか
- [ ] タイトルの「気になる部位を選んでください」が表示されているか
- [ ] ３つの部位（首 / 肩 / 腰）のカードが表示されているか
- [ ] カードにカーソルを乗せると影が濃くなるか
- [ ] スマホサイズにした際に、カードが縦に並ぶか


## 関連 issue
Closes #9 