### PR TITLE
feat:ストレッチ一覧画面の実装

### DIFF
--- a/app/controllers/stretches_controller.rb
+++ b/app/controllers/stretches_controller.rb
@@ -1,0 +1,11 @@
+class StretchesController < ApplicationController
+  def index
+    @target_area = params[:target_area]
+
+    @stretches = if @target_area.present?
+                  Stretch.where(target_area: @target_area)
+                 else
+                  Stretch.all
+                 end
+  end
+end

--- a/app/helpers/stretches_helper.rb
+++ b/app/helpers/stretches_helper.rb
@@ -1,0 +1,2 @@
+module StretchesHelper
+end

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -8,7 +8,7 @@
         <div class="text-6xl mb-4">💪</div>
         <h3 class="text-2xl font-bold mb-2">肩</h3>
         <p class="text-gray-600 mb-4">肩こりや肩の疲れに</p>
-        <%= link_to 'タップして選択', '#', class: 'inline-block bg-blue-500 text-white px-6 py-2 rounded-lg hover:bg-blue-600 transition-colors' %>
+        <%= link_to 'タップして選択', stretches_path(target_area: 'shoulder'), class: 'inline-block bg-blue-500 text-white px-6 py-2 rounded-lg hover:bg-blue-600 transition-colors' %>
       </div>
     </div>
 
@@ -18,7 +18,7 @@
         <div class="text-6xl mb-4">🦒</div>
         <h3 class="text-2xl font-bold mb-2">首</h3>
         <p class="text-gray-600 mb-4">首の疲れやこりに</p>
-        <%= link_to 'タップして選択', '#', class: 'inline-block bg-blue-500 text-white px-6 py-2 rounded-lg hover:bg-blue-600 transition-colors' %>
+        <%= link_to 'タップして選択', stretches_path(target_area: 'neck'), class: 'inline-block bg-blue-500 text-white px-6 py-2 rounded-lg hover:bg-blue-600 transition-colors' %>
       </div>
     </div>
     
@@ -28,7 +28,7 @@
         <div class="text-6xl mb-4">🧘</div>
         <h3 class="text-2xl font-bold mb-2">腰</h3>
         <p class="text-gray-600 mb-4">腰痛や腰の疲れに</p>
-        <%= link_to 'タップして選択', '#', class: 'inline-block bg-blue-500 text-white px-6 py-2 rounded-lg hover:bg-blue-600 transition-colors' %>
+        <%= link_to 'タップして選択', stretches_path(target_area: 'lower_back'), class: 'inline-block bg-blue-500 text-white px-6 py-2 rounded-lg hover:bg-blue-600 transition-colors' %>
       </div>
     </div>    
   </div>

--- a/app/views/stretches/index.html.erb
+++ b/app/views/stretches/index.html.erb
@@ -1,0 +1,41 @@
+<div class="max-w-7xl mx-auto px-4 py-8">
+  <%= link_to root_path, class: "inline-flex items-center text-blue-600 hover:text-blue-800 mb-6 transition-colors" do %>
+    <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
+    </svg>
+    トップに戻る
+  <% end %>
+
+  <h1 class="text-3xl font-bold text-center text-gray-800 mb-8">
+    <% if @target_area.present? %>
+      <%= @target_area %> のストレッチ
+    <% else %>
+      全てのストレッチ
+    <% end %>
+  </h1>
+  
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    <% if @stretches.empty? %>
+      <div class="col-span-full text-center py-12">
+        <p class="text-gray-500 text-lg">該当するストレッチが見つかりませんでした。</p>
+      </div>
+    <% else %>
+      <% @stretches.each do |stretch| %>
+        
+        <div class="bg-white rounded-lg shadow-md hover:shadow-xl transition-shadow duration-300 p-6">
+          <h2 class="text-xl font-semibold text-gray-800 mb-3">
+            <%= stretch.name %>
+          </h2>
+          <span class="inline-block bg-blue-500 text-white text-sm px-3 py-1 rounded-full mb-3">
+            選択
+          </span>
+          <p class="text-gray-600 leading-relaxed">
+            <%= stretch.description %>
+          </p>
+        </div>
+
+      <% end %>
+
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,6 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root "static_pages#top"
+
+  resources :stretches, only: %i[index]
 end

--- a/test/controllers/stretches_controller_test.rb
+++ b/test/controllers/stretches_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class StretchesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
issue #10   で提起された ストレッチ一覧画面を実装する。

## 変更内容
- ルーティングの設定
  - stretchesのルーティングを設定をする。（アクション：indexのみ）

- コントローラーの作成
  - `stretches_controller`の生成
  - indexアクションの定義


- ビュー
- `stretches/index.html.erb`の生成・編集
- トップページとのパスを通す。


## 動作確認
      
- [ ] トップページから各ストレッチをクリックするとそれぞれの一覧ページに遷移するか
- [ ] 「トップに戻る」をクリックするとトップページに遷移するか
- [ ] カードにカーソルを乗せると影が濃くなるか
- [ ] スマホサイズにした際に、カードが縦に並ぶか


## 関連 issue
Closes #10 