### PR TITLE
Feature/issue 13 record registration

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -10,9 +10,9 @@ class RecordsController < ApplicationController
     # @record.user = current_user
 
     if @record.save
-      redirect_to root_path, notice: 'お疲れ様でした！記録をカレンダーに登録しました🎉'
+      redirect_to root_path, notice: "お疲れ様でした！記録をカレンダーに登録しました🎉"
     else
-      flash.now[:alert] = '記録の登録に失敗しました'
+      flash.now[:alert] = "記録の登録に失敗しました"
       render :new, status: :unprocesaable_entity
     end
   end

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,0 +1,28 @@
+class RecordsController < ApplicationController
+  before_action :set_stretch, only: %i[new create]
+
+  def new
+    @record = Record.new
+  end
+
+  def create
+    @record = @stretch.records.build(record_params)
+    # @record.user = current_user
+
+    if @record.save
+      redirect_to root_path, notice: 'お疲れ様でした！記録をカレンダーに登録しました🎉'
+    else
+      flash.now[:alert] = '記録の登録に失敗しました'
+      render :new, status: :unprocesaable_entity
+    end
+  end
+
+  private
+  def set_stretch
+    @stretch = Stretch.find(params[:stretch_id])
+  end
+
+  def record_params
+    params.require(:record).permit(:date)
+  end
+end

--- a/app/helpers/records_helper.rb
+++ b/app/helpers/records_helper.rb
@@ -1,0 +1,2 @@
+module RecordsHelper
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
     <%= render 'shared/header' %>
 
     <main class="flex-glow container mx-auto px-4 py-8">
+    <%= render 'shared/flash_message' %>
       <%= yield %>
     </main>
 

--- a/app/views/records/new.html.erb
+++ b/app/views/records/new.html.erb
@@ -1,0 +1,42 @@
+<div class="min-h-screen flex items-center jistiy-center bg-gradient-to-br from-green-50 to-blue-50">
+  <div class="bg-white rounded-lg shadow-xl p-8 max-w-md w-full">
+    <!-- 達成メッセージ -->
+    <div class="text-center mb-8">
+      <div class="text-6xl mb-4">🎉</div>
+      <h1 class="text-3xl font-bold text-gray-800 mb-2">達成！</h1>
+      <p class="text-xl text-gray-600">お疲れ様でした！</p>
+    </div>
+
+    <!-- ストレッチ情報 -->
+    <div class="bg-gray-50 rounded-lg p-4 mb-6">
+      <p class="text-sm textgray-500 mb-1">完了したストレッチ</p>
+      <p class="text-lg font-semibold text-gray-800"><%= @stretch.name %></p>
+    </div>
+
+    <!-- フォーム -->
+    <%= form_with model: @record, url: stretch_records_path(@stretch), local: true do | f| %>
+      <!-- 完了日時（自動で現在時刻を設定） -->
+      <%= f.hidden_field :date, value: Date.current %>
+
+      <!-- ボタン -->
+      <div class="space-y-3">
+        <!--カレンダーに登録ボタン -->
+        <%= f.submit 'カレンダーに登録', 
+            class: 'w-full bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-4 rounded-lg transition duration-200 ease-in-out transform hover:scale-105' %>
+        
+        <!-- トップに戻るボタン -->
+        <%= link_to 'トップに戻る',
+            root_path,
+            class: 'block w-full text-center bg-gray-200 hover:bg-gray-300 text-gray-700 font-bold py-3 px-4 rounded-lg transition duration-200 ease-in-out',
+            data: { turbo: false } %>
+      </div>
+    <% end %>
+
+    <!-- 励ましメッセージ -->
+    <div class="mt-6 text-center">
+      <p class="text-sm text-gray-500">
+        継続は力なり！明日も頑張りましょう💪
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,5 @@
+<% flash.each do |message_type, message| %>
+  <div class="alert alert-<%= message_type %>">
+    <%= message %>
+  </div>
+<% end %>

--- a/app/views/stretches/show.html.erb
+++ b/app/views/stretches/show.html.erb
@@ -21,7 +21,7 @@
 
     <!-- カウントダウン表示（画像の上に重ねる） -->
       <div class="absolute inset-0 flex items-center justify-center">
-        <p class="text-6xl font-bold text-white bg-black bg-opacity-50 px-8 py-4 rounded-lg" id="timer-display">
+        <p class="text-6xl font-bold text-white bg-black bg-opacity-50 px-8 py-4 rounded-lg" id="timer-display" data-stretch-id="<%= @stretch.id %>">
           01:00
         </p>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,14 @@
 Rails.application.routes.draw do
+  get "records/new"
+  get "records/create"
   root "static_pages#top"
   get "static_pages/top"
 
   get "up" => "rails/health#show", as: :rails_health_check
 
-  resources :stretches, only: %i[index show]
+  resources :stretches, only: %i[index show] do
+    resources :records, only: %i[new create]
+  end
+
+  resources :records, only: %i[index show]
 end

--- a/test/controllers/records_controller_test.rb
+++ b/test/controllers/records_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class RecordsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get records_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get records_create_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
issue #13  で提起された 記録登録画面の実装をしました。

## 変更内容
- ルーティング追加（resources :stretch内にネスト）
- コントローラの作成 / 編集（`records_controller`）
  - new, createアクション
- ビューファイルの作成・編集（`new.html.erb`）


## 動作確認
以下の手順をブラウザで実行してみる。

- [ ] ストレッチ詳細ページでタイマーを開始
- [ ] 終了ボタンをクリック
- [ ] 記録登録画面に遷移
- [ ] 「カレンダーに登録」ボタンをクリック
- [ ] データが保存される（consoleで`Records.all`を実行し確認）
- [ ] トップページにリダイレクトされる
- [ ] 「お疲れ様でした！記録をカレンダーに登録しました🎉」というメッセージが表示される


## 関連 issue
Closes #13 
