### PR TITLE
Feature/issue 16 error handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,10 @@ gem "bootsnap", require: false
 
 gem "simple_calendar", "~> 2.4"
 
+gem "rails-i18n", "~> 7.0.0"
+
+gem "enum_help", "0.0.19"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     drb (2.2.3)
+    enum_help (0.0.19)
+      activesupport (>= 3.0.0)
     erb (6.0.2)
     erubi (1.13.1)
     foreman (0.90.0)
@@ -220,6 +222,9 @@ GEM
     rails-html-sanitizer (1.7.0)
       loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.2.3.1)
       actionpack (= 7.2.3.1)
       activesupport (= 7.2.3.1)
@@ -342,12 +347,14 @@ DEPENDENCIES
   brakeman
   capybara
   debug
+  enum_help (= 0.0.19)
   foreman
   importmap-rails
   jbuilder
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.3, >= 7.2.3.1)
+  rails-i18n (~> 7.0.0)
   rubocop-rails-omakase
   selenium-webdriver
   simple_calendar (~> 2.4)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,12 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+
+  private
+
+  def render_404
+    render file: Rails.root.join('public/404.html'), status: :not_found, layout: false
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,6 @@ class ApplicationController < ActionController::Base
   private
 
   def render_404
-    render file: Rails.root.join('public/404.html'), status: :not_found, layout: false
+    render file: Rails.root.join("public/404.html"), status: :not_found, layout: false
   end
 end

--- a/app/controllers/stretches_controller.rb
+++ b/app/controllers/stretches_controller.rb
@@ -1,12 +1,20 @@
 class StretchesController < ApplicationController
   def index
-    @target_area = params[:target_area]
-
-    @stretches = if @target_area.present?
-                  Stretch.where(target_area: @target_area)
-    else
-                  Stretch.all
-    end
+    target_area_key = params[:target_area]
+    
+    # target_area_keyが存在する場合、日本語化した値を@target_areaに代入
+    @target_area = if target_area_key.present?
+                     I18n.t("activerecord.attributes.stretch.target_area.#{target_area_key}")
+                   else
+                     nil
+                   end
+    
+    # 検索条件を設定
+    @stretches = if target_area_key.present?
+                   Stretch.where(target_area: target_area_key)
+                 else
+                   Stretch.all
+                 end
   end
 
   def show

--- a/app/controllers/stretches_controller.rb
+++ b/app/controllers/stretches_controller.rb
@@ -1,20 +1,20 @@
 class StretchesController < ApplicationController
   def index
     target_area_key = params[:target_area]
-    
+
     # target_area_keyが存在する場合、日本語化した値を@target_areaに代入
     @target_area = if target_area_key.present?
                      I18n.t("activerecord.attributes.stretch.target_area.#{target_area_key}")
-                   else
+    else
                      nil
-                   end
-    
+    end
+
     # 検索条件を設定
     @stretches = if target_area_key.present?
                    Stretch.where(target_area: target_area_key)
-                 else
+    else
                    Stretch.all
-                 end
+    end
   end
 
   def show

--- a/app/models/stretch.rb
+++ b/app/models/stretch.rb
@@ -1,5 +1,5 @@
 class Stretch < ApplicationRecord
-  enum target_area: {
+  enum :target_area, {
     shoulder: 0,
     neck: 1,
     lower_back: 2

--- a/app/views/stretches/index.html.erb
+++ b/app/views/stretches/index.html.erb
@@ -8,9 +8,9 @@
 
   <h1 class="text-3xl font-bold text-center text-gray-800 mb-8">
     <% if @target_area.present? %>
-      <%= @target_area %> のストレッチ
+      <%= t('.title_with_area', target_area: @target_area) %>
     <% else %>
-      全てのストレッチ
+      <%= t('.title_all') %>
     <% end %>
   </h1>
   

--- a/app/views/stretches/show.html.erb
+++ b/app/views/stretches/show.html.erb
@@ -56,10 +56,6 @@
         <h1 class="text-3xl font-bold text-gray-800 mb-3">
           <%= @stretch.name %>
         </h1>
-  
-        <span class="inline-block bg-blue-500 text-white text-sm px-4 py-2 rounded-full">
-          <%= @stretch.target_area %>
-        </span>
       </div>
       
       

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,8 @@ module Myapp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # i18n化
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,11 @@
+ja:
+  activerecord:
+    models:
+      stretch: ストレッチ
+      record: 記録
+    attributes:
+      stretch:
+        target_area:
+          shoulder: 肩
+          neck: 首
+          lower_back: 腰

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,9 @@
+ja:
+  stretches:
+    index:
+      title: ストレッチ一覧
+      title_with_area: "%{target_area}のストレッチ"
+      title_all: 全てのストレッチ
+    show:
+      title: ストレッチ詳細
+

--- a/public/404.html
+++ b/public/404.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>The page you were looking for doesn't exist (404)</title>
+  <title>404 Not Found</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   .rails-default-error-page {
@@ -58,10 +58,11 @@
   <!-- This file lives in public/404.html -->
   <div class="dialog">
     <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
+      <h1>お探しのページが見つかりません</h1>
+      <p>URLが間違っているか、ページが削除された可能性があります。</p>
+      <a href="/">トップページに戻る</a>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
+    <!-- <p>If you are the application owner check the logs for more information.</p> -->
   </div>
 </body>
 </html>


### PR DESCRIPTION
## 概要
issue #16  で提起された エラーハンドリングを実装しました。

## 変更内容
- 404ページを実装
- i18nの実装(`gem rails-i18n`, `~> 7.0.0`)

## 動作確認
- [ ] 存在しないページにアクセスして、404ページが表示される
- [ ] 404ページから「トップページに戻る」ボタンをクリックした時にトップページに遷移される
- [ ] ストレッチ詳細ページのタイトルが、部位も含めて日本語になっている。（i18nで日本語化）


## 関連 issue
Closes #16 
