### PR TITLE
fix:gem tailwindcss-railsのバージョン固定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "turbo-rails"
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails"
 # Use Tailwind CSS [https://github.com/rails/tailwindcss-rails]
-gem "tailwindcss-rails"
+gem "tailwindcss-rails", "~> 3.3.1"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "turbo-rails"
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails"
 # Use Tailwind CSS [https://github.com/rails/tailwindcss-rails]
-gem "tailwindcss-rails", "~> 3.3.1"
+gem "tailwindcss-rails", "~> 4.0"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,13 +298,13 @@ GEM
     tailwindcss-rails (4.4.0)
       railties (>= 7.0.0)
       tailwindcss-ruby (~> 4.0)
-    tailwindcss-ruby (4.2.1)
-    tailwindcss-ruby (4.2.1-aarch64-linux-gnu)
-    tailwindcss-ruby (4.2.1-aarch64-linux-musl)
-    tailwindcss-ruby (4.2.1-arm64-darwin)
-    tailwindcss-ruby (4.2.1-x86_64-darwin)
-    tailwindcss-ruby (4.2.1-x86_64-linux-gnu)
-    tailwindcss-ruby (4.2.1-x86_64-linux-musl)
+    tailwindcss-ruby (4.2.2)
+    tailwindcss-ruby (4.2.2-aarch64-linux-gnu)
+    tailwindcss-ruby (4.2.2-aarch64-linux-musl)
+    tailwindcss-ruby (4.2.2-arm64-darwin)
+    tailwindcss-ruby (4.2.2-x86_64-darwin)
+    tailwindcss-ruby (4.2.2-x86_64-linux-gnu)
+    tailwindcss-ruby (4.2.2-x86_64-linux-musl)
     thor (1.5.0)
     timeout (0.6.1)
     tsort (0.2.0)
@@ -360,7 +360,7 @@ DEPENDENCIES
   simple_calendar (~> 2.4)
   sprockets-rails
   stimulus-rails
-  tailwindcss-rails
+  tailwindcss-rails (~> 4.0)
   turbo-rails
   tzinfo-data
   web-console


### PR DESCRIPTION
## 概要
デプロイする上でのエラー修正を行いました。

## 変更内容
- Gemfileの修正
  - gem "tailwindcss-rails"のバージョンを"~> 3.3.1"に固定。


`Render上で発生したエラーログ`
```
Post-install message from tailwindcss-rails:
== Upgrading to Tailwind CSS v4 ==
If you are upgrading to tailwindcss-rails 4.x, please read the upgrade guide at:
  https://github.com/rails/tailwindcss-rails/blob/main/README.md#upgrading-your-application-from-tailwind-v3-to-v4
If you're not ready to upgrade yet, please pin to version 3 in your Gemfile:
  gem "tailwindcss-rails", "~> 3.3.1"
bin/rails aborted!
ArgumentError: key must be 16 bytes (ArgumentError)
        cipher.key = @secret
                     ^^^^^^^
/opt/render/project/src/config/environment.rb:5:in `<main>'
Tasks: TOP => environment
(See full trace by running task with --trace)
==> Build failed 😞
```